### PR TITLE
docs(extensions): clarify chainlink-data-feed is frontend-only (no contract to deploy)

### DIFF
--- a/docs/deploying/deploy-smart-contracts.mdx
+++ b/docs/deploying/deploy-smart-contracts.mdx
@@ -18,7 +18,7 @@ For local development, you need to start a local Stylus-compatible network first
 yarn chain
 ```
 
-This command starts a local Stylus-compatible network using the Nitro dev node script (`./nitro-devnode/run-dev-node.sh`). The network runs on your local machine and can be used for testing and development. You can customize the Nitro dev node configuration in the `nitro-devnode` submodule.
+This command starts a local Stylus-compatible network using the Nitro dev node script (`./nitro-devnode/run-dev-node.sh`). The network runs on your local machine and can be used for testing and development. You can customize the Nitro dev node configuration in the vendored `nitro-devnode` directory.
 
 ### Available Networks
 

--- a/docs/extensions/howToInstall.md
+++ b/docs/extensions/howToInstall.md
@@ -34,4 +34,9 @@ E.g.: `npx create-stylus@latest -e erc-20`
 
 ## Available Extensions
 
+Extensions come in two shapes:
+
+- **Contract extensions** (erc-20, erc-721, chainlink-vrf): scaffold a Stylus smart contract that you can deploy with `yarn deploy`.
+- **Frontend-only extensions** (chainlink-data-feed): provide UI components and hooks that read data from an existing on-chain contract (e.g., a Chainlink price feed via `packages/nextjs/contracts/externalContracts.ts`). There is no contract to deploy — `yarn deploy` is a friendly no-op. Use `yarn start` to run the UI.
+
 You can find a complete list of available extensions on [scaffold-stylus extensions](https://github.com/Arb-Stylus/create-stylus/blob/main/src/extensions.json).

--- a/docs/quick-start/environment.mdx
+++ b/docs/quick-start/environment.mdx
@@ -18,7 +18,7 @@ In the first terminal, start a local Stylus-compatible network:
 yarn chain
 ```
 
-This command starts a local Arbitrum network using the Nitro dev node. The network runs on your local machine and can be used for testing and development. You can customize the Nitro dev node configuration in `packages/stylus/nitro-devnode`.
+This command starts a local Arbitrum network using the Nitro dev node. The network runs on your local machine and can be used for testing and development. You can customize the Nitro dev node configuration in the `nitro-devnode` directory at the project root.
 
 ## 2. Deploy Your Smart Contract
 


### PR DESCRIPTION
Summarizes the two extension shapes in `howToInstall.md`:

- **Contract extensions** (erc-20, erc-721, chainlink-vrf): scaffold a Stylus smart contract you deploy.
- **Frontend-only extensions** (chainlink-data-feed): provide UI + hooks that read an existing on-chain contract via `externalContracts.ts` — no contract to deploy; `yarn deploy` is a friendly no-op.

Also fixes two secondary docs issues verified against scaffold-stylus source:
- `deploy-smart-contracts.mdx`: nitro-devnode is a vendored directory, not a git submodule (confirmed: `.gitmodules` is empty in `create-stylus/templates/base/`)
- `environment.mdx`: nitro-devnode lives at project root (`./nitro-devnode`), not `packages/stylus/nitro-devnode` (confirmed via `package.json`: `"chain": "./nitro-devnode/start-chain-with-cors.sh"`)

Related: create-stylus-extensions PR #12 (friendly no-op for `yarn deploy` in chainlink-data-feed projects).