### PR TITLE
docs: align install/toolchain with scaffold v0.2.0 (cargo-stylus 0.10.8, rustc 1.91.0, drop stylusup)

### DIFF
--- a/docs/deploying/deploy-to-orbit-chains.mdx
+++ b/docs/deploying/deploy-to-orbit-chains.mdx
@@ -10,7 +10,7 @@ Orbit chains are custom Layer 2 solutions built on Arbitrum's technology stack. 
 
 Before deploying to Orbit chains, ensure you have:
 
-1. **Stylus CLI tools installed** (version 0.10.2)
+1. **Stylus CLI tools installed** (version 0.10.8)
 2. **Proper environment configuration** for your target Orbit chain
 3. **Contract initialization setup** (Orbit chains require `initialize()` function instead of constructors)
 

--- a/docs/quick-start/installation.mdx
+++ b/docs/quick-start/installation.mdx
@@ -26,28 +26,7 @@ Scaffold-Stylus currently does not support Windows natively. If you're using Win
 For WSL setup, follow the [Microsoft WSL installation guide](https://docs.microsoft.com/en-us/windows/wsl/install).
 :::
 
-## Easy installation with stylusup (Recommended):
-
-Tool for installing all the Stylus essentials for development. [Stylusup](https://stylusup.sh/#) will install the latest stable versions of:
-
-- [Rust](https://www.rust-lang.org/tools/install) (if not present) to provide the core programming environment.
-- [cargo-stylus](https://github.com/OffchainLabs/cargo-stylus/blob/main/README.md) (latest version) a tool for creating and managing Stylus projects.
-- Adding WebAssembly support to compile Rust code for blockchain environments.
-- Optionally collecting and sending telemetry data to track installation statistics.
-
-```bash
-curl -s https://stylusup.sh/install.sh | sh
-```
-
-:::note
-`stylusup` installs the **latest** version of cargo-stylus (currently 0.10.x), which is **compatible** with the Scaffold-Stylus base template. To guarantee the exact tested version, pin explicitly:
-
-```bash
-cargo install --force --locked cargo-stylus@0.10.2
-```
-:::
-
-## Alternatively: Install Rust and the Stylus CLI tool with Cargo:
+## Install Rust and the Stylus CLI tool with Cargo:
 
 ### Install Rust:
 
@@ -59,20 +38,24 @@ Check the [Rust installation guide](https://www.rust-lang.org/tools/install) for
 
 ### Install the Stylus CLI tool with Cargo:
 
+:::warning
+This project requires `cargo-stylus` version `0.10.8` and `rustc` version `1.91.0` (as pinned in `packages/stylus/contracts/rust-toolchain.toml`). Do NOT use `stylusup` to install Stylus tools, as it installs the latest versions which are incompatible with these pinned requirements.
+:::
+
 ```bash
-cargo install --force --locked cargo-stylus@0.10.2
+cargo install --force --locked cargo-stylus@0.10.8
 ```
 
 **Prerequisite:**
 
-- `cargo-stylus` version `0.10.2`
+- `cargo-stylus` version `0.10.8`
 - `rustc` version match with `packages/stylus/contracts/rust-toolchain.toml`
 
 Set default `toolchain` match `rust-toolchain.toml` and add the `wasm32-unknown-unknown` build target to your Rust compiler:
 
 ```bash
-rustup default 1.89
-rustup target add wasm32-unknown-unknown --toolchain 1.89
+rustup default 1.91.0
+rustup target add wasm32-unknown-unknown --toolchain 1.91.0
 ```
 
 You should now have it available as a Cargo subcommand:

--- a/docs/quick-start/troubleshooting.mdx
+++ b/docs/quick-start/troubleshooting.mdx
@@ -118,8 +118,8 @@ If your Rust contract fails to compile:
 1. **Check Rust toolchain**: Ensure you're using the correct Rust version
 
    ```bash
-   rustup default 1.87
-   rustup target add wasm32-unknown-unknown --toolchain 1.87
+   rustup default 1.91.0
+   rustup target add wasm32-unknown-unknown --toolchain 1.91.0
    ```
 
 2. **Verify dependencies**: Check that all dependencies in `Cargo.toml` are compatible


### PR DESCRIPTION
## Summary
- Update `docs/quick-start/installation.mdx` to require `cargo-stylus` `0.10.8` and `rustc` `1.91.0` (was `0.10.2` / `1.89`), matching `packages/stylus/contracts/rust-toolchain.toml` on scaffold-stylus `main` (v0.2.0).
- Remove the `stylusup` "Easy installation" path — scaffold-stylus main now explicitly warns against it since it installs unpinned/incompatible versions.
- Fix a stale `cargo-stylus` version reference (`0.10.2` -> `0.10.8`) in `docs/deploying/deploy-to-orbit-chains.mdx`.

## Test plan
- [x] `npm run build` (Docusaurus) succeeds with no broken links/errors.
- [x] Cross-checked pinned versions against `Arb-Stylus/scaffold-stylus@main`'s `readme.md` and `packages/stylus/contracts/rust-toolchain.toml`.