### PR TITLE
fix(docs): point footer link to live landing site (scaffoldstylus.quantum3labs.com)

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -88,7 +88,7 @@ const config = {
         items: [
           // commented until Scaffold-Stylus website is launched
           {
-            href: "https://www.scaffoldstylus.com/",
+            href: "https://scaffoldstylus.quantum3labs.com/",
             label: "Scaffold-Stylus Website",
             position: "left",
           },


### PR DESCRIPTION
## Summary
- The old landing site `https://www.scaffoldstylus.com/` is dead (SSL error, verified).
- The live landing site is now `https://scaffoldstylus.quantum3labs.com/` (verified 200).
- Updated **only** the footer "Scaffold-Stylus Website" link `href` in `docusaurus.config.js` to point to the live domain.

## Deliberately left unchanged
- Top-level `url` field (`https://docs.scaffoldstylus.io`)
- `baseUrl`
- Plausible `data-domain` (`docs.scaffoldstylus.io`)

Reason: the replacement docs domain is unknown; guessing would break canonical URLs and the sitemap. Only the dead footer link was fixed.

## Grep results
Searched the repo for any other occurrence of `www.scaffoldstylus.com` (and `scaffoldstylus.com` case-insensitively) — no other occurrences found outside the one line changed here.

## Test plan
- [x] `npm run build` completes successfully (green)
- [x] `git diff` confirms only the one footer `href` line changed in `docusaurus.config.js`