### PR TITLE
fix(docs): point canonical URL and sitemap at the live GitHub Pages host

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -71,7 +71,7 @@ The deployment is configured in `docusaurus.config.js`:
 - **Organization:** `Arb-Stylus`
 - **Project:** `scaffold-stylus-docs`
 - **Base URL:** `/scaffold-stylus-docs/`
-- **Production URL:** `https://docs.scaffoldstylus.io`
+- **Production URL:** `https://arb-stylus.github.io/scaffold-stylus-docs/`
 
 ## Troubleshooting
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -11,7 +11,7 @@ const config = {
   favicon: "img/favicon.png",
 
   // Set the production url of your site here
-  url: "https://docs.scaffoldstylus.io",
+  url: "https://arb-stylus.github.io",
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: "/scaffold-stylus-docs/",


### PR DESCRIPTION
## Summary

- `scaffoldstylus.io` is **not registered** (`whois scaffoldstylus.io` → domain not found), so the Docusaurus `url` field in `docusaurus.config.js` was advertising a nonexistent host in every canonical `<link>` tag and all 40 `sitemap.xml` entries.
- The site actually deploys to GitHub Pages via `.github/workflows/deploy.yml`, live at `https://arb-stylus.github.io/scaffold-stylus-docs/` (verified HTTP 200). `gh api repos/Arb-Stylus/scaffold-stylus-docs/pages` confirms no custom domain is configured (`cname: null`).
- Changed the top-level `url` in `docusaurus.config.js` from `https://docs.scaffoldstylus.io` to `https://arb-stylus.github.io`. Combined with the existing `baseUrl: "/scaffold-stylus-docs/"`, this produces the correct live URL for canonical tags and the sitemap.
- Updated the stale `Production URL` line in `DEPLOYMENT.md` to match.

**Deliberately left alone:** the Plausible `data-domain` (`docs.scaffoldstylus.io`) in `docusaurus.config.js`. Plausible keys analytics by the domain registered in the account, so changing it without account access would silently drop all analytics. That's a separate decision for whoever owns the Plausible account.

## Grep results (other `docs.scaffoldstylus.io` occurrences)

Only one other occurrence exists in the repo, and it's the expected/untouched one:
- `docusaurus.config.js:39` — `"data-domain": "docs.scaffoldstylus.io"` (Plausible analytics key, intentionally left as-is per above)

## Verification

`npm run build` — green. Confirmed in `build/sitemap.xml`:
- 0 remaining occurrences of `docs.scaffoldstylus.io`
- All `<loc>` entries now use `https://arb-stylus.github.io/scaffold-stylus-docs/...`, e.g.:
  ```
  <url><loc>https://arb-stylus.github.io/scaffold-stylus-docs/</loc>...</url>
  ```
Also confirmed the built `index.html` canonical tag:
```
<link rel="canonical" href="https://arb-stylus.github.io/scaffold-stylus-docs/">
```
and that `data-domain="docs.scaffoldstylus.io"` is unchanged.

## Test plan

- [x] `npm run build` completes successfully
- [x] `build/sitemap.xml` `<loc>` entries point at `arb-stylus.github.io`
- [x] `build/index.html` canonical tag points at `arb-stylus.github.io`
- [x] Plausible `data-domain` unchanged